### PR TITLE
Remove Kong logo image URL from frontmatter

### DIFF
--- a/docs/API/KongAPI.md
+++ b/docs/API/KongAPI.md
@@ -1,7 +1,6 @@
 ---
 description: Quickly build API-centric applications. Leverage the latest microservice and container design patterns. And tie it all together with the Kong microservice API gateway.
 title: API Gateway (powered by Kong CE)
-image: "https://raw.githubusercontent.com/Kong/docker-official-docs/master/kong/logo.png"
 author: ll911 leo.lou@gov.bc.ca
 ---
 ## API Gateway (powered by Kong CE)


### PR DESCRIPTION
The Kong logo that is referenced in `docs/API/KongAPI.md` points to a third party repository is missing/moved and returns a 404. This 404 error breaks the DevHub build process (see [example build](https://github.com/bcgov/devhub-app-web/runs/6086272793?check_suite_focus=true)). Removing this logo will mean it no longer shows up in the Kong card in DevHub, as it does now in production:

<img width="1840" alt="Kong logo shown on card in DevHub" src="https://user-images.githubusercontent.com/25143706/164123977-92942d44-56df-4b4a-b5fc-a2db6d2f2ccd.png">

If we decide it is necessary to display this logo, we should do it by hosting the file in the DevHub repository itself, to prevent future breakages like this.

@mitovskaol could you please confirm this is okay?